### PR TITLE
fix: prevent unwanted zoom scaling on larger screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <base href="/">
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <title>pxflux</title>
   <link rel="shortcut icon" href="/static/favicon.ico" type="image/x-icon">

--- a/src/assets/sass/_base.scss
+++ b/src/assets/sass/_base.scss
@@ -19,27 +19,27 @@ $breakpoint-map: (
   0: (
     start: 0px,
     max: 420px,
-    rootsize: $baseline
+    rootsize: 12px
   ),
   1: (
     start: 480px,
     max: 560px,
-    rootsize: $baseline
+    rootsize: 12px
   ),
   2: (
     start: 768px,
     max: 840px,
-    rootsize: $baseline
+    rootsize: 12px
   ),
   3: (
     start: 980px,
     max: 1080px,
-    rootsize: $baseline
+    rootsize: 12px
   ),
   4: (
     start: 1280px,
     max: 1440px,
-    rootsize: $baseline
+    rootsize: 12px
   )
 );
 // Set cap height to set to the baseline.


### PR DESCRIPTION
Fixes the zoom issue where text and images appeared oversized.

## Changes
- Set consistent 12px root font size across all breakpoints
- Remove restrictive viewport zoom controls for better accessibility
- Prevents megatype system from scaling up text on larger screens

Resolves #17

Generated with [Claude Code](https://claude.ai/code)